### PR TITLE
chore: remove prettier trailing comma all

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,3 +1,1 @@
-module.exports = {
-  trailingComma: "all",
-};
+module.exports = {};


### PR DESCRIPTION
it became default in prettier 3

close #111